### PR TITLE
[SM-2764] javax.validation exports the wrong package version

### DIFF
--- a/jsr303-api-1.1.0/pom.xml
+++ b/jsr303-api-1.1.0/pom.xml
@@ -55,7 +55,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Description>${project.description}</Bundle-Description>
-                        <Export-Package>javax.validation*;version=1.0.0;-split-package:=merge-first;-noimport:=true</Export-Package>
+                        <Export-Package>javax.validation*;version=1.1.0;-split-package:=merge-first;-noimport:=true</Export-Package>
                         <Import-Package>*</Import-Package>
                         <Private-Package>org.apache.servicemix.specs.locator;-split-package:=merge-first</Private-Package>
                         <Bundle-Activator>org.apache.servicemix.specs.locator.Activator</Bundle-Activator>


### PR DESCRIPTION
Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/SM-2764

Andrea
