### PR TITLE
SM-2938 MailcapCommandMap cannot find content_handler for image/jpeg

### DIFF
--- a/activation-api-1.1/src/main/java/javax/activation/MailcapCommandMap.java
+++ b/activation-api-1.1/src/main/java/javax/activation/MailcapCommandMap.java
@@ -426,16 +426,17 @@ public class MailcapCommandMap extends CommandMap {
         if (i != -1) {
             mimeType = mimeType.substring(0, i).trim();
         }
+        cmdName = cmdName.toLowerCase();
 
         // search for an exact match
         Map commands = (Map) preferredCommands.get(mimeType);
-        if (commands == null) {
+        if (commands == null || commands.get(cmdName) == null) {
             // then a wild card match
             commands = (Map) preferredCommands.get(getWildcardMimeType(mimeType));
-            if (commands == null) {
+            if (commands == null || commands.get(cmdName) == null) {
                 // then fallback searches, both standard and wild card.
                 commands = (Map) fallbackCommands.get(mimeType);
-                if (commands == null) {
+                if (commands == null || commands.get(cmdName) == null) {
                     commands = (Map) fallbackCommands.get(getWildcardMimeType(mimeType));
                 }
                 if (commands == null) {
@@ -443,7 +444,7 @@ public class MailcapCommandMap extends CommandMap {
                 }
             }
         }
-        return (CommandInfo) commands.get(cmdName.toLowerCase());
+        return (CommandInfo) commands.get(cmdName);
     }
 
     private String getWildcardMimeType(String mimeType) {


### PR DESCRIPTION
There may be a command map which doesn't contains desired command. Actually Java8 contains following entry which creates a command map without content_handler. In this case it also try with wildcard match and even fallback entries.
image/jpeg;;            x-java-view=com.sun.activation.viewers.ImageViewer
