### PR TITLE
annotation bundle is empty

### DIFF
--- a/annotation-api-1.2/pom.xml
+++ b/annotation-api-1.2/pom.xml
@@ -56,9 +56,8 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Description>${project.description}</Bundle-Description>
                         <Export-Package>javax.annotation*;version=1.2;-split-package:=merge-first;-noimport:=true</Export-Package>
-                        <Import-Package>
-                            *
-                        </Import-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package />
                         <Implementation-Title>Apache ServiceMix</Implementation-Title>
                         <Implementation-Version>${project.version}</Implementation-Version>
                     </instructions>


### PR DESCRIPTION
The produced and released annotation artifact is empty (only MANIFEST.MF), so it's could not be used. Never version of maven-bundle-plugin has change some behaviour, so Private-Package header now is needed
