### PR TITLE
Fixes a bug in javax.activation.DataHandler

### DIFF
--- a/activation-api-1.1/src/main/java/javax/activation/DataHandler.java
+++ b/activation-api-1.1/src/main/java/javax/activation/DataHandler.java
@@ -246,7 +246,7 @@ public class DataHandler implements Transferable {
                 dch = localFactory.createDataContentHandler(mimeType);
             }
             if (dch == null) {
-                dch = CommandMap.getDefaultCommandMap().createDataContentHandler(mimeType);
+                dch = getCommandMap().createDataContentHandler(mimeType);
             }
         }
         return dch;


### PR DESCRIPTION
Fixes a bug in javax.activation.DataHandler which causes previously set by the user CommandMaps to be ignored