### PR TITLE
POM: fix wrong version in name

### DIFF
--- a/activation-api-1.1/pom.xml
+++ b/activation-api-1.1/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
     <packaging>bundle</packaging>
     <version>2.10-SNAPSHOT</version>
-    <name>Apache ServiceMix :: Specs :: Activation API 1.4</name>
+    <name>Apache ServiceMix :: Specs :: Activation API 1.1</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Since there is only a 1.1.1 download I suspect this is, as the package names say only 1.1 spec.

X-Signed-Off: ecki@apache.org