### PR TITLE
[JSONP] Add an OSGi contract for JSONP 1.1

### DIFF
--- a/json-api-1.1/pom.xml
+++ b/json-api-1.1/pom.xml
@@ -61,6 +61,7 @@
                         <Bundle-Activator>org.apache.servicemix.specs.locator.Activator</Bundle-Activator>
                         <Implementation-Title>Apache ServiceMix</Implementation-Title>
                         <Implementation-Version>${project.version}</Implementation-Version>
+                        <Provide-Capability>osgi.contract;osgi.contract=JavaJSONP;version:List&lt;Version&gt;="1,1.1";uses:="javax.json,javax.json.spi,javax.json.stream"</Provide-Capability>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.4.0</version>
+                    <version>3.4.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
In pretty much all cases JSR spec bundles should define the contract that they provide. This helps to protects users against the lack of semantic versioning in future JSRs.

This change adds the contract for JSONP 1.1 (which is backward compatible with 1), and updates the maven-bundle plugin to be new enough to cope with lists of versions in a capability version attribute.