### PR TITLE
SM-4383: prevent duplicate CommandInfo and reset OSGi CommandMap's currentBundle

### DIFF
--- a/activation-api-1.1/pom.xml
+++ b/activation-api-1.1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.servicemix.specs</groupId>
         <artifactId>specs-pom</artifactId>
-        <version>1-SNAPSHOT</version>
+        <version>3-SNAPSHOT</version>
         <relativePath>../specs-pom/pom.xml</relativePath>
     </parent>
 
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.servicemix.specs</groupId>
             <artifactId>org.apache.servicemix.specs.locator</artifactId>
-            <version>2.10-SNAPSHOT</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -57,6 +57,12 @@
             <artifactId>org.osgi.core</artifactId>
             <version>1.4.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -127,6 +133,22 @@
                             <createSourcesJar>${createSourcesJar}</createSourcesJar>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                        	<argLine>-Djava.endorsed.dirs=${project.build.directory}</argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/activation-api-1.1/pom.xml
+++ b/activation-api-1.1/pom.xml
@@ -64,6 +64,12 @@
             <version>4.13</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -148,7 +154,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                        	<argLine>-Djava.endorsed.dirs=${project.build.directory}</argLine>
+                            <argLine>-Djava.endorsed.dirs=${project.build.directory},${maven.dependency.org.osgi.core.jar.path}</argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/activation-api-1.1/src/main/java/javax/activation/MailcapCommandMap.java
+++ b/activation-api-1.1/src/main/java/javax/activation/MailcapCommandMap.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -277,11 +276,21 @@ public class MailcapCommandMap extends CommandMap {
                     cmdList = new ArrayList();
                     allCommands.put(mimeType, cmdList);
                 }
-                cmdList.add(info);
+                addUnique(cmdList, info);
             }
         }
     }
 
+    private void addUnique(List commands, CommandInfo newCommand) {
+        for (Iterator i = commands.iterator(); i.hasNext();) {
+            CommandInfo info = (CommandInfo)i.next();
+            if (info.getCommandName().equals(newCommand.getCommandName())
+                    && info.getCommandClass().equals(newCommand.getCommandClass())) {
+                return;
+            }
+        }
+        commands.add(newCommand);
+    }
 
     /**
      * Add a command to a target command list (preferred or fallback).

--- a/activation-api-1.1/src/main/java/org/apache/servicemix/specs/activation/Activator.java
+++ b/activation-api-1.1/src/main/java/org/apache/servicemix/specs/activation/Activator.java
@@ -99,6 +99,7 @@ public class Activator extends org.apache.servicemix.specs.locator.Activator {
                     commandMap.addMailcap(line, mailcap.bundle);
                 }
             }
+            commandMap.addMailcap("", null);
             CommandMap.setDefaultCommandMap(commandMap);
         } finally {
             Thread.currentThread().setContextClassLoader(tccl);

--- a/activation-api-1.1/src/test/java/javax/activation/ITBugDuplicatedMaincapRegistrations.java
+++ b/activation-api-1.1/src/test/java/javax/activation/ITBugDuplicatedMaincapRegistrations.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020, MP Objects, http://www.mp-objects.com
+ */
+package javax.activation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+
+/**
+ * SM-4383. Filter out duplicate registrations of a command.
+ */
+public class ITBugDuplicatedMaincapRegistrations {
+
+    private static final String MIMETYPE = "example/sm-4383";
+
+    private static final String MAILCAP = MIMETYPE+";; x-java-content-handler=some.value";
+
+    @Test
+    public void testFilterDuplicates() {
+        MailcapCommandMap mc = new MailcapCommandMap();
+
+        assertEquals(0, mc.getAllCommands(MIMETYPE).length);
+
+        mc.addMailcap(MAILCAP);
+        mc.addMailcap(MAILCAP);
+        assertEquals(1, mc.getAllCommands(MIMETYPE).length);
+
+        mc.addMailcap(MAILCAP+".alt");
+        assertEquals(2, mc.getAllCommands(MIMETYPE).length);
+	}
+
+}

--- a/activation-api-1.1/src/test/java/org/apache/servicemix/specs/activation/ITClearCurrentBundle.java
+++ b/activation-api-1.1/src/test/java/org/apache/servicemix/specs/activation/ITClearCurrentBundle.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020, MP Objects, http://www.mp-objects.com
+ */
+package org.apache.servicemix.specs.activation;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+
+import javax.activation.CommandMap;
+import javax.activation.DataContentHandler;
+
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+
+/**
+ * After Activator.rebuildCommandMap the currentBundle of OsgiMailcapCommandMap should be null, so that calls
+ * to addMailcap do not register with the last started bundle.
+ */
+public class ITClearCurrentBundle {
+
+	@After
+	public void tearDown() {
+		CommandMap.setDefaultCommandMap(null);
+	}
+
+	@Test
+	public void testClearCurrentBundle() throws Exception {
+		Activator activator = new Activator();
+		Bundle bundle = createBundle(ITClearCurrentBundle.class.getResource("/mailcap.example"));
+		
+		activator.register(bundle);
+		
+		assertTrue(CommandMap.getDefaultCommandMap() instanceof OsgiMailcapCommandMap);
+		assertNullCurrentBundle((OsgiMailcapCommandMap) CommandMap.getDefaultCommandMap());
+	}
+
+	private void assertNullCurrentBundle(OsgiMailcapCommandMap commandMap) throws Exception {
+		Field field = OsgiMailcapCommandMap.class.getDeclaredField("currentBundle");
+		boolean oldAccessible = field.isAccessible();
+		try {
+			field.setAccessible(true);
+			assertNull(field.get(commandMap));
+		}
+		finally {
+			field.setAccessible(oldAccessible);
+		}
+	}
+
+	private Bundle createBundle(URL mailcapResource) throws Exception {
+		Bundle result = Mockito.mock(Bundle.class);
+		Mockito.when(result.loadClass("javax.activation.DataContentHandler")).thenReturn(DataContentHandler.class);
+		Mockito.when(result.getResource("/META-INF/mailcap")).thenReturn(mailcapResource);
+		return result;
+	}
+}

--- a/activation-api-1.1/src/test/resources/mailcap.example
+++ b/activation-api-1.1/src/test/resources/mailcap.example
@@ -1,0 +1,2 @@
+# Example mailcap
+example/sm-4383;; x-java-content-handler=some.value


### PR DESCRIPTION
Contains two fixes for the problems mentioned in https://issues.apache.org/jira/browse/SM-4383

The two unit tests require to be run as a maven integration test to allow for using Java's endorsed dirs construction to work. Otherwise the default javax.activation packages are being used.