### PR TITLE
[SM-4352]: Fix server cannot start when using activation-api-1.2.1, b…

### DIFF
--- a/activation-api-1.2.1/src/main/java/javax/activation/MailcapCommandMap.java
+++ b/activation-api-1.2.1/src/main/java/javax/activation/MailcapCommandMap.java
@@ -41,6 +41,10 @@ import java.util.Map;
  * @version $Rev$ $Date$
  */
 public class MailcapCommandMap extends CommandMap {
+    /**
+     * A string that holds all the special chars.
+     */
+    private static final String TSPECIALS = "()<>@,;:/[]?=\\\"";
     private final Map mimeTypes = new HashMap();
     private final Map preferredCommands = new HashMap();
     private final Map allCommands = new HashMap();
@@ -310,7 +314,7 @@ public class MailcapCommandMap extends CommandMap {
     }
 
     private int getToken(String s, int index) {
-        while (index < s.length() && s.charAt(index) != '#' && !MimeType.isSpecial(s.charAt(index))) {
+        while (index < s.length() && s.charAt(index) != '#' && !isSpecialCharacter(s.charAt(index))) {
             index++;
         }
         return index;
@@ -503,5 +507,9 @@ public class MailcapCommandMap extends CommandMap {
             return new String[0];
         }
         return (String[])commands.toArray(new String[commands.size()]);
+    }
+    
+    private boolean isSpecialCharacter(char c) {
+        return Character.isWhitespace(c) || Character.isISOControl(c) || TSPECIALS.indexOf(c) != -1;
     }
 }


### PR DESCRIPTION
Fix server (karaf) cannot start when using activation-api-1.2.1, because MimeType.isSpecial doesn't exist.
The change was also preventing before sending emails from karaf container using java mail api.
Spec was also not compiling before the change.